### PR TITLE
- Updating Microsoft.Owin nupkg from 2.0.2.0 to 3.0.0.0

### DIFF
--- a/src/Nancy.MSOwinSecurity.Tests/Nancy.MSOwinSecurity.Tests.csproj
+++ b/src/Nancy.MSOwinSecurity.Tests/Nancy.MSOwinSecurity.Tests.csproj
@@ -35,9 +35,8 @@
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Nancy">
       <HintPath>..\packages\Nancy.0.21.1\lib\net40\Nancy.dll</HintPath>

--- a/src/Nancy.MSOwinSecurity.Tests/packages.config
+++ b/src/Nancy.MSOwinSecurity.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="2.1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Nancy" version="0.21.1" targetFramework="net45" />
   <package id="Nancy.Owin" version="0.21.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.csproj
+++ b/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=2.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.Owin, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Owin.2.0.2\lib\net45\Microsoft.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Owin.3.0.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Nancy, Version=0.21.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Nancy.MSOwinSecurity/packages.config
+++ b/src/Nancy.MSOwinSecurity/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Owin" version="2.0.2" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Nancy" version="0.21.1" targetFramework="net45" />
   <package id="Nancy.Owin" version="0.21.1" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
I got a runtime exception using the latest Nancy and Owin with Nancy.MSOwinSecurity. I updated the package locally built and inserted it into my project to make sure it worked. Sure enough that did the trick.