### PR TITLE
Return Forbidden when missing required claims.

### DIFF
--- a/src/Nancy.MSOwinSecurity.Tests/NancyModuleExtensionsTests.cs
+++ b/src/Nancy.MSOwinSecurity.Tests/NancyModuleExtensionsTests.cs
@@ -6,8 +6,8 @@
     using System.Security.Claims;
     using System.Threading;
     using FluentAssertions;
-    using Nancy.Owin;
-    using Nancy.Security.Annotations;
+    using Owin;
+    using Annotations;
     using Xunit;
 
     [UsedImplicitly]
@@ -88,13 +88,13 @@
             }
 
             [Fact]
-            public void When_authenticated_and_claims_not_valid_should_get_unauthorized()
+            public void When_authenticated_and_claims_not_valid_should_get_Forbidden()
             {
-                _environment[ServerUserKey] = new ClaimsPrincipal(new ClaimsIdentity());
+                _environment[ServerUserKey] = new ClaimsPrincipal(new ClaimsIdentity(new Claim[0], "Custom"));
 
                 Response response = _testModule.InvokeBeforePipeLine(_context);
 
-                response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+                response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
             }
 
             [Fact]

--- a/src/Nancy.MSOwinSecurity/NancyModuleExtensions.cs
+++ b/src/Nancy.MSOwinSecurity/NancyModuleExtensions.cs
@@ -4,7 +4,7 @@
     using System.Linq;
     using System.Security.Claims;
     using Microsoft.Owin.Security;
-    using Nancy.Extensions;
+    using Extensions;
 
     public static class NancyModuleExtensions
     {
@@ -22,9 +22,10 @@
                     : (Response)null;
             }, "Requires MS Owin authentication");
         }
-        
+
         /// <summary>
         ///     This module requires the security claims to be validated.
+        ///     If the users claims do not match the required claims then a <see cref="HttpStatusCode.Forbidden"/> is returned.
         /// </summary>
         /// <param name="module"></param>
         /// <param name="isValid"></param>
@@ -36,7 +37,7 @@
                 IAuthenticationManager auth = ctx.GetAuthenticationManager();
                 return isValid(auth.User.Claims.ToArray())
                     ? (Response)null
-                    : HttpStatusCode.Unauthorized;
+                    : HttpStatusCode.Forbidden;
             }, "Requires valid security claims");
         }
     }


### PR DESCRIPTION
#9 - Changed the Module RequiresSecurityClaims extension so that a Forbidden is returned instead of an Unauthorized.

The two tests "With_authentication_manager_and_a_user_then_should_get_null" where failing prior to my change.
