### PR TITLE
Support for Nancy v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 Nancy.MSOwinSecurity
 ===================
 
-Enables integration with Microsoft's OWIN security middeware from the Katana project. This package will allow you to easily access the IAuthenticationManager. .NET 4.5 only.
+Enables integration with Microsoft's OWIN security middeware from the Katana
+project. This package will allow you to easily access the *IAuthenticationManager*.
+This version supports *Nancy v2* on .NET 4.5.2 (or greater) only. When using
+*Nancy v1*, please use *Nancy.MSOwinSecurity v2* instead.
 
 How to use
 -
 
 Installing the nuget package:
+
 ```
 install-package Nancy.MSOwinSecurity
 ```
+
 Getting the authentication manager and current user from the context:
 
 ```C#
@@ -27,7 +32,7 @@ public class MyModule : NancyModule
             //authenticationManager.AuthenticateAsync(..);
             //authenticationManager.Challenge(..);
         };
-    
+
         // v2.x Route Syntax
         Get("/", _ =>
         {
@@ -41,23 +46,27 @@ public class MyModule : NancyModule
     }
 }
 ```
+
 Securing a module:
+
 ```C#
 public class MyModule : NancyModule
 {
     public MyModule()
     {
         this.RequiresMSOwinAuthentication();
-        
+
         // v1.x Route Syntax
         Get["/"] = _ => {...});
-        
+
         // v2.x Route Syntax
         Get("/", _ => {...});
     }
 }
 ```
+
 Securing a route:
+
 ```C#
 public class MyModule : NancyModule
 {
@@ -69,8 +78,8 @@ public class MyModule : NancyModule
             this.RequiresMSOwinAuthentication();
             ....
         });
-        
-        // v2.x Route Syntax        
+
+        // v2.x Route Syntax
         Get("/", _ => 
         {
             this.RequiresMSOwinAuthentication();
@@ -79,7 +88,9 @@ public class MyModule : NancyModule
     }
 }
 ```
+
 Getting the current user (just a helper extension around IAuthenticationManager.User):
+
 ```C#
 public class MyModule : NancyModule
 {
@@ -91,7 +102,7 @@ public class MyModule : NancyModule
             ClaimsPrincipal = Context.GetMSOwinUser();
             ....
         });
-        
+
         // v2.x Route Syntax 
         Get("/", _ => 
         {
@@ -100,9 +111,11 @@ public class MyModule : NancyModule
         });
     }
 }
+
 ```
 Authorizing the user at module level:
 ```C#
+
 public class MyModule : NancyModule
 {
     public MyModule()
@@ -110,13 +123,13 @@ public class MyModule : NancyModule
         this.RequiresSecurityClaims(claims => claims.Any(claim =>
             claim.ClaimType = ClaimTypes.Country &&
             claim.Value.Equals("IE", StringComparision.Ordinal)));
-        
+
         // v1.x route syntax 
         Get["/"] = _ => 
         {
            ....
         });
-        
+
         // v2.x Route Syntax 
         Get("/",  _ => 
         {
@@ -124,9 +137,11 @@ public class MyModule : NancyModule
         });
     }
 }
+
 ```
 Authorizing the user at route level:
 ```C#
+
 public class MyModule : NancyModule
 {
     public MyModule()
@@ -151,7 +166,7 @@ public class MyModule : NancyModule
 }
 ```
 
-Personal note: this nancy extension package would integrate much better if we had extenstion properties in c# :(
+Personal note: this nancy extension package would integrate much better if we had extension properties in c# :(
 
 License
 -

--- a/src/Nancy.MSOwinSecurity.Tests/Nancy.MSOwinSecurity.Tests.csproj
+++ b/src/Nancy.MSOwinSecurity.Tests/Nancy.MSOwinSecurity.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nancy.Security</RootNamespace>
     <AssemblyName>Nancy.MSOwinSecurity.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,17 +36,15 @@
     <Reference Include="FluentAssertions">
       <HintPath>..\packages\FluentAssertions.2.1.0.0\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.2.0.0\lib\net452\Nancy.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy.Owin, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.Owin.1.4.1\lib\net40\Nancy.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy.Owin, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.Owin.2.0.0\lib\net452\Nancy.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -69,7 +68,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nancy.MSOwinSecurity\Nancy.MSOwinSecurity.csproj">

--- a/src/Nancy.MSOwinSecurity.Tests/packages.config
+++ b/src/Nancy.MSOwinSecurity.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.1.0.0" targetFramework="net45" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
-  <package id="Nancy" version="1.4.1" targetFramework="net45" />
-  <package id="Nancy.Owin" version="1.4.1" targetFramework="net45" />
-  <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="FluentAssertions" version="2.1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="4.0.1" targetFramework="net452" />
+  <package id="Nancy" version="2.0.0" targetFramework="net452" />
+  <package id="Nancy.Owin" version="2.0.0" targetFramework="net452" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="xunit" version="1.9.2" targetFramework="net452" />
 </packages>

--- a/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.csproj
+++ b/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Nancy.Security</RootNamespace>
     <AssemblyName>Nancy.MSOwinSecurity</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -33,19 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.2.0.0\lib\net452\Nancy.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy.Owin, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.Owin.1.4.1\lib\net40\Nancy.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy.Owin, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.Owin.2.0.0\lib\net452\Nancy.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Owin">
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
@@ -62,7 +60,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Nancy.MSOwinSecurity.nuspec" />
+    <None Include="Nancy.MSOwinSecurity.nuspec">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.nuspec
+++ b/src/Nancy.MSOwinSecurity/Nancy.MSOwinSecurity.nuspec
@@ -2,23 +2,23 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <id>Nancy.MSOwinSecurity</id>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <authors>Damian Hickey</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Enables Nancy integration with Microsoft.Owin.Security middleware.</description>
     <language>en-US</language>
-	<copyright>Damian Hickey</copyright>
-	<iconUrl>http://nancyfx.org/nancy-nuget.png</iconUrl>
+    <copyright>Damian Hickey</copyright>
+    <iconUrl>http://nancyfx.org/nancy-nuget.png</iconUrl>
     <licenseUrl>https://github.com/damianh/Nancy.MSOwinSecurity/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/damianh/Nancy.MSOwinSecurity</projectUrl>
     <dependencies>
-        <dependency id="Nancy" version="[1.0,2.0)"/>
-        <dependency id="Microsoft.Owin" version="[3.0, )" />
+        <dependency id="Nancy" version="[2.0,3.0)"/>
+        <dependency id="Microsoft.Owin" version="[4.0.1, )" />
     </dependencies>
     <tags>Nancy, OWIN, Katana</tags>
   </metadata>
   <files>
-    <file src="bin\Release\Nancy.MSOwinSecurity.dll" target="lib\net45" />
-    <file src="bin\Release\Nancy.MSOwinSecurity.pdb" target="lib\net45" />
+    <file src="bin\Release\Nancy.MSOwinSecurity.dll" target="lib\net452" />
+    <file src="bin\Release\Nancy.MSOwinSecurity.pdb" target="lib\net452" />
   </files>
 </package>

--- a/src/Nancy.MSOwinSecurity/NancyModuleExtensions.cs
+++ b/src/Nancy.MSOwinSecurity/NancyModuleExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace Nancy.Security
+﻿
+namespace Nancy.Security
 {
     using System;
     using System.Linq;

--- a/src/Nancy.MSOwinSecurity/packages.config
+++ b/src/Nancy.MSOwinSecurity/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
-  <package id="Nancy" version="1.4.1" targetFramework="net45" />
-  <package id="Nancy.Owin" version="1.4.1" targetFramework="net45" />
-  <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="4.0.1" targetFramework="net452" />
+  <package id="Nancy" version="2.0.0" targetFramework="net452" />
+  <package id="Nancy.Owin" version="2.0.0" targetFramework="net452" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This PR contains changes to support Nancy v2.

I've raised the minimum required .NET framework to 4.5.2 and updated the Nuget package references accordingly. The only thing is that 2 unit tests fail, but the returned result of the tested method seems ok for me. Could you please have a look at it?

Note: This PR breaks compatibility with previous versions as the library now references Nancy v2 components. It will not work with Nancy v1, so I added a note into README.md to inform users.
